### PR TITLE
#8 feat: add avoid keyboard scroll view

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1380,7 +1380,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: d3f49c53809116a5d38da093a8aa78bf551aed09
+  boost: 26fad476bfa736552bbfa698a06cc530475c1505
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
   FBLazyVector: fbc4957d9aa695250b55d879c1d86f79d7e69ab4
@@ -1394,7 +1394,7 @@ SPEC CHECKSUMS:
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   FlipperKit: 37525a5d056ef9b93d1578e04bc3ea1de940094f
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
+  glog: 035f1e36e53b355cf70f6434d161b36e7d21fecd
   hermes-engine: b361c9ef5ef3cda53f66e195599b47e1f84ffa35
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
@@ -1452,7 +1452,7 @@ SPEC CHECKSUMS:
   RNScreens: b582cb834dc4133307562e930e8fa914b8c04ef2
   RNSVG: ba3e7232f45e34b7b47e74472386cf4e1a676d0a
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  Yoga: e64aa65de36c0832d04e8c7bd614396c77a80047
+  Yoga: 13c8ef87792450193e117976337b8527b49e8c03
 
 PODFILE CHECKSUM: eb490ed861c0caf2f2649ac9503532c4cce2d3d8
 

--- a/ios/upcy.xcodeproj/project.pbxproj
+++ b/ios/upcy.xcodeproj/project.pbxproj
@@ -690,11 +690,7 @@
 					"-DFOLLY_USE_LIBCPP=1",
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-Wl",
-					"-ld_classic",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;
@@ -763,11 +759,7 @@
 					"-DFOLLY_USE_LIBCPP=1",
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-Wl",
-					"-ld_classic",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-native-dropdown-picker": "^5.4.6",
     "react-native-gesture-handler": "^2.15.0",
     "react-native-image-picker": "^7.1.0",
+    "react-native-keyboard-aware-scroll-view": "^0.9.5",
     "react-native-keychain": "8.1.2",
     "react-native-pager-view": "^6.2.3",
     "react-native-pell-rich-editor": "^1.9.0",

--- a/src/common/CustomScrollView.tsx
+++ b/src/common/CustomScrollView.tsx
@@ -1,0 +1,28 @@
+import { DimensionValue } from 'react-native';
+import {
+  KeyboardAwareScrollViewProps,
+  KeyboardAwareScrollView,
+} from 'react-native-keyboard-aware-scroll-view';
+
+interface CustomScrollViewProps extends KeyboardAwareScrollViewProps {
+  minHeight?: DimensionValue;
+  children: any;
+}
+
+const CustomScrollView = ({
+  minHeight,
+  children,
+  ...props
+}: CustomScrollViewProps) => {
+  return (
+    <KeyboardAwareScrollView
+      extraScrollHeight={10}
+      alwaysBounceVertical={false}
+      contentContainerStyle={{ flexGrow: 1, minHeight: minHeight }}
+      {...props}>
+      {children}
+    </KeyboardAwareScrollView>
+  );
+};
+
+export default CustomScrollView;

--- a/src/components/Auth/BasicForm.tsx
+++ b/src/components/Auth/BasicForm.tsx
@@ -8,10 +8,9 @@ import {
 } from 'react-native';
 import { Body16B, Body16M, Caption11M } from '../../styles/GlobalText';
 import styled from 'styled-components/native';
-import { BLACK, BLACK2, GRAY, PURPLE } from '../../styles/GlobalColor';
+import { BLACK2, GRAY, PURPLE } from '../../styles/GlobalColor';
 import CheckIcon from '../../assets/common/CheckIcon.svg';
 import DownArrow from '../../assets/common/DownArrow.svg';
-import RightArrow from '../../assets/common/RightArrow.svg';
 import LeftArrow from '../../assets/common/Arrow.svg';
 import Logo from '../../assets/common/Logo.svg';
 import { FormProps } from './SignIn';
@@ -23,6 +22,7 @@ import RegionModal from './RegionModal';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import SelectBox from '../../common/SelectBox';
 import BasicSignupSplash from './BasicSignupSplash';
+import CustomScrollView from '../../common/CustomScrollView';
 
 interface SignupProps {
   mail: string;
@@ -112,7 +112,7 @@ export default function BasicForm({ navigation, route }: FormProps) {
         <BasicSignupSplash />
       ) : (
         <SafeAreaView style={{ flex: 1, backgroundColor: 'white' }}>
-          <ScrollView>
+          <CustomScrollView>
             <View style={{ flex: 1, minHeight: 800 }}>
               <TouchableOpacity
                 onPress={() => navigation.goBack()}
@@ -316,7 +316,7 @@ export default function BasicForm({ navigation, route }: FormProps) {
                 />
               </View>
             </View>
-          </ScrollView>
+          </CustomScrollView>
         </SafeAreaView>
       )}
     </BottomSheetModalProvider>

--- a/src/components/Auth/Reformer/CareerModal.tsx
+++ b/src/components/Auth/Reformer/CareerModal.tsx
@@ -25,6 +25,7 @@ import SelectBox from '../../../common/SelectBox';
 import Dropdown from '../../../common/Dropdown';
 import PeriodPicker from '../../../common/PeriodPicker';
 import FileBox from '../../../common/FileBox';
+import CustomScrollView from '../../../common/CustomScrollView';
 
 interface CareerModalProps extends ModalProps {
   index: number;
@@ -300,9 +301,7 @@ export default function CareerModal({
           </View>
         </>
       ) : (
-        <ScrollView
-          alwaysBounceVertical={false}
-          contentContainerStyle={{ flexGrow: 1, minHeight: 700 }}>
+        <CustomScrollView minHeight={700}>
           <View
             style={{
               marginHorizontal: width * 0.04,
@@ -363,7 +362,7 @@ export default function CareerModal({
               />
             </View>
           </View>
-        </ScrollView>
+        </CustomScrollView>
       )}
     </BottomSheetModal>
   );

--- a/src/components/Auth/Reformer/EducationModal.tsx
+++ b/src/components/Auth/Reformer/EducationModal.tsx
@@ -21,6 +21,7 @@ import { ModalProps } from './Reformer';
 import InputView from '../../../common/InputView';
 import SelectBox from '../../../common/SelectBox';
 import FileBox from '../../../common/FileBox';
+import CustomScrollView from '../../../common/CustomScrollView';
 
 export default function EducationModal({
   open,
@@ -96,9 +97,7 @@ export default function EducationModal({
       backdropComponent={renderBackdrop}
       onChange={handleSheetChanges}>
       {section === 'init' ? (
-        <ScrollView
-          alwaysBounceVertical={false}
-          contentContainerStyle={{ flexGrow: 1, minHeight: 700 }}>
+        <CustomScrollView minHeight={700}>
           <View
             style={{
               marginHorizontal: width * 0.04,
@@ -176,7 +175,7 @@ export default function EducationModal({
               />
             </View>
           </View>
-        </ScrollView>
+        </CustomScrollView>
       ) : (
         <>
           <View style={styles.selectItem}>

--- a/src/components/Auth/Reformer/ReformFormCareer.tsx
+++ b/src/components/Auth/Reformer/ReformFormCareer.tsx
@@ -3,7 +3,6 @@ import {
   View,
   Dimensions,
   StyleSheet,
-  ScrollView,
   Alert,
 } from 'react-native';
 import styled from 'styled-components/native';
@@ -17,6 +16,7 @@ import { BLACK, BLACK2, GRAY } from '../../../styles/GlobalColor';
 import EducationModal from './EducationModal';
 import SelectBox from '../../../common/SelectBox';
 import CareerModal from './CareerModal';
+import CustomScrollView from '../../../common/CustomScrollView';
 
 const SelectView = styled.View`
   display: flex;
@@ -97,12 +97,7 @@ export default function ReformCareer({ setNext, form, setForm }: PageProps) {
 
   return (
     <SafeAreaView style={{ flex: 1 }}>
-      <ScrollView
-        alwaysBounceVertical={false}
-        contentContainerStyle={{
-          minHeight: 500,
-          flexGrow: 1,
-        }}>
+      <CustomScrollView minHeight={500}>
         <View style={{ flexGrow: 1 }}>
           <View style={{ marginHorizontal: width * 0.04 }}>
             <View style={styles.formView}>
@@ -156,7 +151,7 @@ export default function ReformCareer({ setNext, form, setForm }: PageProps) {
             />
           </View>
         </View>
-      </ScrollView>
+      </CustomScrollView>
       <EducationModal
         open={educationModal}
         setOpen={setEducationModal}

--- a/src/components/Auth/Reformer/ReformFormProfile.tsx
+++ b/src/components/Auth/Reformer/ReformFormProfile.tsx
@@ -4,6 +4,7 @@ import BottomButton from '../../../common/BottomButton';
 import PencilIcon from '../../../assets/common/Pencil.svg';
 import InputView from '../../../common/InputView';
 import PhotoOptions from '../../../common/PhotoOptions';
+import CustomScrollView from '../../../common/CustomScrollView';
 
 function ProfilePic({ form, setForm }: ReformProps) {
   return (
@@ -63,12 +64,10 @@ export default function ReformFormProfile({
 
   return (
     <SafeAreaView style={{ flex: 1 }}>
-      <ScrollView
-        alwaysBounceVertical={false}
+      <CustomScrollView
         contentContainerStyle={{
           minHeight: 650,
           marginHorizontal: width * 0.04,
-          flexGrow: 1,
         }}>
         <View style={{ flexGrow: 1 }}>
           <ProfilePic form={form} setForm={setForm} />
@@ -125,7 +124,7 @@ export default function ReformFormProfile({
             }}
           />
         </View>
-      </ScrollView>
+      </CustomScrollView>
     </SafeAreaView>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6778,6 +6778,19 @@ react-native-image-picker@^7.1.0:
   resolved "https://registry.yarnpkg.com/react-native-image-picker/-/react-native-image-picker-7.1.1.tgz#89ea4611d5a05e4748adefef9bdf22e175f6f56d"
   integrity sha512-8zQS8RJkGq+jV6bzmIQ560QL2tccXUwouDWktJt7typfNu/QpuDm9pnESeLkdA5MHGTMm8YR09tcV1qtBD+0fg==
 
+react-native-iphone-x-helper@^1.0.3:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz#20c603e9a0e765fd6f97396638bdeb0e5a60b010"
+  integrity sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==
+
+react-native-keyboard-aware-scroll-view@^0.9.5:
+  version "0.9.5"
+  resolved "https://registry.yarnpkg.com/react-native-keyboard-aware-scroll-view/-/react-native-keyboard-aware-scroll-view-0.9.5.tgz#e2e9665d320c188e6b1f22f151b94eb358bf9b71"
+  integrity sha512-XwfRn+T/qBH9WjTWIBiJD2hPWg0yJvtaEw6RtPCa5/PYHabzBaWxYBOl0usXN/368BL1XktnZPh8C2lmTpOREA==
+  dependencies:
+    prop-types "^15.6.2"
+    react-native-iphone-x-helper "^1.0.3"
+
 react-native-keychain@8.1.2:
   version "8.1.2"
   resolved "https://registry.yarnpkg.com/react-native-keychain/-/react-native-keychain-8.1.2.tgz#34291ae472878e5124d081211af5ede7d810e64f"


### PR DESCRIPTION
### 작업 내용
* 공통 컴포넌트 CustomScrollView 추가
> KeyboardAwareScrollView 기반
TextInput 포커싱 시 키보드 영역 위로 이동 (안드로이드 환경 확인 필요)
minHeight prop을 통해 부모 컴포넌트의 높이가 최소값 미만일 경우 스크롤 되도록 설정 가능
* 기본 가입, 리포머 프로필 등록 파트에서 적용