### PR TITLE
#61 refactor: replace PhotoOptions with useImagePicker

### DIFF
--- a/src/common/PhotoOptions.tsx
+++ b/src/common/PhotoOptions.tsx
@@ -12,15 +12,12 @@ import {
   Text,
   ViewStyle,
   Image,
-  ImageStyle,
-  ImageBackground,
 } from 'react-native';
 import * as ImagePicker from 'react-native-image-picker';
 import styled from 'styled-components/native';
 import PhotoIcon from '../assets/common/Photo.svg';
 import { Body14M } from '../styles/GlobalText';
-import { LIGHTGRAY, LIGHTGRAY2 } from '../styles/GlobalColor';
-import Carousel from './Carousel';
+import { LIGHTGRAY } from '../styles/GlobalColor';
 
 const PhotosInput = styled.View`
   display: flex;
@@ -36,9 +33,7 @@ interface Action {
 interface PhotoProps {
   buttonLabel?: string;
   style?: ViewStyle;
-  imageStyle?: ImageStyle;
-  containerStyle?: ViewStyle;
-  photo?: undefined | PhotoResultProps[];
+  photo?: undefined | PhotoResultProps;
   setPhoto: (p: PhotoResultProps[]) => void;
   max: number;
 }
@@ -56,8 +51,6 @@ const PhotoOptions = ({
   setPhoto,
   max,
   style,
-  imageStyle,
-  containerStyle,
 }: PhotoProps) => {
   const CameraActions: Action[] = [
     //카메라 & 갤러리 세팅
@@ -65,7 +58,7 @@ const PhotoOptions = ({
       title: '카메라',
       type: 'capture',
       options: {
-        selectionLimit: max - (photo === undefined ? 0 : photo.length),
+        selectionLimit: max,
         mediaType: 'photo',
         includeBase64: false,
         maxHeight: 300,
@@ -76,7 +69,7 @@ const PhotoOptions = ({
       title: '앨범',
       type: 'library',
       options: {
-        selectionLimit: max - (photo === undefined ? 0 : photo.length),
+        selectionLimit: max,
         mediaType: 'photo',
         includeBase64: false,
         maxHeight: 300,
@@ -84,6 +77,24 @@ const PhotoOptions = ({
       },
     },
   ];
+  // const onButtonPress = useCallback(
+  //   (
+  //     type: string,
+  //     options: ImagePicker.CameraOptions | ImagePicker.ImageLibraryOptions
+  //   ) => {
+  //     //카메라 & 갤러리 열기
+  //     if (type === "capture") {
+  //       ImagePicker.launchCamera(options, (response) =>
+  //         setPhoto([...photo, response.assets])
+  //       );
+  //     } else {
+  //       ImagePicker.launchImageLibrary(options, (response) =>
+  //         setPhoto([...photo, response.assets])
+  //       );
+  //     }
+  //   },
+  //   []
+  // );
 
   const onButtonPress = useCallback(
     (
@@ -106,8 +117,7 @@ const PhotoOptions = ({
                   uri: asset.uri,
                 };
             });
-            if (photo === undefined) setPhoto(selectedPhotos);
-            else setPhoto(photo.concat(selectedPhotos));
+            setPhoto(selectedPhotos);
           }
         });
       } else {
@@ -126,8 +136,7 @@ const PhotoOptions = ({
                   uri: asset.uri,
                 };
             });
-            if (photo === undefined) setPhoto(selectedPhotos);
-            else setPhoto(photo.concat(selectedPhotos));
+            setPhoto(selectedPhotos);
           }
         });
       }
@@ -136,89 +145,47 @@ const PhotoOptions = ({
   );
 
   return (
-    <View style={{ backgroundColor: LIGHTGRAY2, ...containerStyle }}>
-      <PhotosInput>
-        <View style={{ flex: 1 }}>
-          <Carousel
-            data={
-              photo === undefined
-                ? [undefined]
-                : photo.length < max
-                  ? [photo, undefined]
-                  : photo
-            }
-            renderItem={({
-              item,
-              idx,
-            }: {
-              item: undefined | PhotoResultProps;
-              idx: number;
-            }) => {
-              return (
-                <View key={idx}>
-                  {item === undefined ? (
-                    <TouchableOpacity
-                      style={{
-                        flexDirection: 'row',
-                        alignItems: 'center',
-                        paddingHorizontal: 16,
-                        backgroundColor: 'LIGHTGRAY',
-                        borderRadius: 6,
-                        marginBottom: 20,
-                        paddingVertical: 6,
-                        ...style,
-                      }}
-                      onPress={() => {
-                        Alert.alert('사진 선택', '', [
-                          {
-                            text: '카메라',
-                            onPress: () =>
-                              onButtonPress(
-                                CameraActions[0].type,
-                                CameraActions[0].options,
-                              ),
-                          },
-                          {
-                            text: '앨범',
-                            onPress: () =>
-                              onButtonPress(
-                                CameraActions[1].type,
-                                CameraActions[1].options,
-                              ),
-                          },
-                          { text: '취소', style: 'destructive' },
-                        ]);
-                      }}>
-                      {buttonLabel && (
-                        <>
-                          <PhotoIcon />
-                          <Body14M style={{ marginLeft: 10 }}>
-                            {buttonLabel}
-                          </Body14M>
-                        </>
-                      )}
-                    </TouchableOpacity>
-                  ) : (
-                    <></>
-                  )}
-                </View>
-                // item.map((subItem: any) => (
-                //   <View style={{ height: 350, paddingLeft: 20, paddingRight: 20, paddingTop: 20 }}>
-                //     <ImageBackground
-                //       key={subItem.id}
-                //       source={{ uri: subItem.uri }}
-                //       style={{ width: "auto", height: "100%" }}
-                //       alt={subItem.fileName}
-                //     />
-                //   </View>
-                // ))
-              );
-            }}
-            slider={photo !== undefined && photo.length > 0}
+    <PhotosInput>
+      <TouchableOpacity
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          paddingHorizontal: 16,
+          backgroundColor: 'LIGHTGRAY',
+          borderRadius: 6,
+          marginBottom: 20,
+          paddingVertical: 6,
+          ...style,
+        }}
+        onPress={() => {
+          Alert.alert('사진 선택', '', [
+            {
+              text: '카메라',
+              onPress: () =>
+                onButtonPress(CameraActions[0].type, CameraActions[0].options),
+            },
+            {
+              text: '앨범',
+              onPress: () =>
+                onButtonPress(CameraActions[1].type, CameraActions[1].options),
+            },
+            { text: '취소', style: 'destructive' },
+          ]);
+        }}>
+        {buttonLabel && (
+          <>
+            <PhotoIcon />
+            <Body14M style={{ marginLeft: 10 }}>{buttonLabel}</Body14M>
+          </>
+        )}
+        {photo !== undefined && (
+          <Image
+            source={{ uri: photo.uri }}
+            style={{ height: '100%', width: '100%', borderRadius: 100 }}
           />
-        </View>
-      </PhotosInput>
-    </View>
+        )}
+      </TouchableOpacity>
+    </PhotosInput>
   );
 };
 

--- a/src/components/Auth/Reformer/ReformFormProfile.tsx
+++ b/src/components/Auth/Reformer/ReformFormProfile.tsx
@@ -14,14 +14,11 @@ import InputView from '../../../common/InputView';
 import PhotoOptions from '../../../common/PhotoOptions';
 import CustomScrollView from '../../../common/CustomScrollView';
 import { useEffect, useState } from 'react';
-import useImagePicker from '../../../hooks/useImagePicker';
+import { useImagePicker } from '../../../hooks/useImagePicker';
 
 function ProfilePic({ form, setForm }: ReformProps) {
   const [photo, setPhoto] = useState(form.picture);
-  const [handleAddButtonPress, handleImagePress] = useImagePicker(
-    photo,
-    setPhoto,
-  );
+  const [handleAddButtonPress, handleImagePress] = useImagePicker(setPhoto);
 
   useEffect(() => {
     setForm(prev => {

--- a/src/components/Auth/Reformer/ReformFormProfile.tsx
+++ b/src/components/Auth/Reformer/ReformFormProfile.tsx
@@ -1,42 +1,71 @@
-import { SafeAreaView, View, Dimensions, ScrollView } from 'react-native';
+import {
+  SafeAreaView,
+  View,
+  Dimensions,
+  ScrollView,
+  TouchableOpacity,
+  ImageBackground,
+  Image,
+} from 'react-native';
 import { PageProps, ReformProps } from './Reformer';
 import BottomButton from '../../../common/BottomButton';
 import PencilIcon from '../../../assets/common/Pencil.svg';
 import InputView from '../../../common/InputView';
 import PhotoOptions from '../../../common/PhotoOptions';
 import CustomScrollView from '../../../common/CustomScrollView';
+import { useEffect, useState } from 'react';
+import useImagePicker from '../../../hooks/useImagePicker';
 
 function ProfilePic({ form, setForm }: ReformProps) {
+  const [photo, setPhoto] = useState(form.picture);
+  const [handleAddButtonPress, handleImagePress] = useImagePicker(
+    photo,
+    setPhoto,
+  );
+
+  useEffect(() => {
+    setForm(prev => {
+      return { ...prev, picture: photo };
+    });
+  }, [photo]);
+
   return (
     <View
       style={{
         marginTop: 30,
-
         alignSelf: 'center',
         position: 'relative',
       }}>
-      <PhotoOptions
-        buttonLabel=""
-        photo={form.picture}
-        setPhoto={p => {
-          setForm(prev => {
-            return { ...prev, picture: p[0] };
-          });
-        }}
-        max={1}
-        style={{
-          position: 'relative',
-          width: 82,
-          height: 82,
-          borderRadius: 100,
-          backgroundColor: '#D9D9D9',
-          paddingVertical: 0,
-          paddingHorizontal: 0,
-          marginBottom: 0,
-        }}
-        imageStyle={{ borderRadius: 100 }}
-      />
-
+      <TouchableOpacity
+        onPress={photo === undefined ? handleAddButtonPress : handleImagePress}>
+        <View
+          // buttonLabel=""
+          // photo={form.picture}
+          // setPhoto={p => {
+          //   setForm(prev => {
+          //     return { ...prev, picture: p[0] };
+          //   });
+          // }}
+          // max={1}
+          style={{
+            position: 'relative',
+            width: 82,
+            height: 82,
+            borderRadius: 100,
+            backgroundColor: '#D9D9D9',
+            paddingVertical: 0,
+            paddingHorizontal: 0,
+            marginBottom: 0,
+          }}>
+          {photo !== undefined && (
+            <Image
+              source={{ uri: photo.uri }}
+              style={{ width: 'auto', height: '100%', borderRadius: 100 }}
+              alt={photo.fileName}
+            />
+          )}
+        </View>
+      </TouchableOpacity>
       <View
         style={{
           position: 'absolute',

--- a/src/components/Auth/Reformer/Reformer.tsx
+++ b/src/components/Auth/Reformer/Reformer.tsx
@@ -13,6 +13,7 @@ import {
 import ReformFormStyle from './ReformFormStyle';
 import ReformCareer from './ReformFormCareer';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
+import { PhotoType } from '../../../hooks/useImagePicker';
 
 type page = 'profile' | 'style' | 'career';
 
@@ -38,7 +39,7 @@ interface BasicFormProp {
 }
 
 type ReformProfileType = {
-  picture: any;
+  picture: undefined | PhotoType;
   nickname: string;
   market: string;
   introduce: string;

--- a/src/components/Home/Portfolio/PortfolioWrite.tsx
+++ b/src/components/Home/Portfolio/PortfolioWrite.tsx
@@ -1,10 +1,9 @@
 import { Dimensions, Image, SafeAreaView, View } from 'react-native';
 import { AddPortfolioProps } from './AddPortfolio';
-import { Body14B, Body16B, Caption12M } from '../../../styles/GlobalText';
+import { Body14M, Body16B, Caption12M } from '../../../styles/GlobalText';
 import DetailScreenHeader from '../components/DetailScreenHeader';
-import PhotoOptions from '../../../common/PhotoOptions';
-import { useState } from 'react';
-import { BLACK2, GRAY, LIGHTGRAY } from '../../../styles/GlobalColor';
+import { useEffect, useState } from 'react';
+import { BLACK2, GRAY } from '../../../styles/GlobalColor';
 import InputView from '../../../common/InputView';
 import CustomScrollView from '../../../common/CustomScrollView';
 import useObjectUpdater from '../../../hooks/useObjectUpdater';
@@ -12,9 +11,12 @@ import PeriodPicker from '../../../common/PeriodPicker';
 import BottomButton from '../../../common/BottomButton';
 import AgreeButton from '../../../common/AgreeButton';
 import HashtagInput from '../components/HashtagInput';
+import PhotoIcon from '../../../assets/common/Photo.svg';
+import { TouchableOpacity } from 'react-native-gesture-handler';
+import { PhotoType, useImagePicker } from '../../../hooks/useImagePicker';
 
 type PortfolioFormType = {
-  photo: any;
+  photo: undefined | PhotoType;
   title: string;
   hashtags: string[];
   domain: string;
@@ -40,9 +42,13 @@ export default function PortfolioWrite({
     information: '',
   };
   const [form, setForm] = useState<PortfolioFormType>(initForm);
+  const [image, setImage] = useState<PhotoType | undefined>(undefined);
   const [agreement, setAgreement] = useState(false);
 
   const formUpdater = useObjectUpdater(setForm);
+  const [handleAddButtonPress, handleImagePress] = useImagePicker(setImage);
+
+  useEffect(() => formUpdater(image, 'photo'), [image]);
 
   const addHashtag = (v: string) => {
     const newHashtags = form.hashtags;
@@ -69,29 +75,33 @@ export default function PortfolioWrite({
           navigation.navigate('TempStorage');
         }}
       />
-      <CustomScrollView minHeight={1430}>
-        <PhotoOptions
-          buttonLabel="이미지 등록"
-          max={1}
-          setPhoto={p =>
-            setForm(prev => {
-              return { ...prev, photo: p[0] };
-            })
-          }
-          containerStyle={{
+      <CustomScrollView minHeight={1400}>
+        <TouchableOpacity
+          style={{
             width: '100%',
             aspectRatio: 1,
             backgroundColor: GRAY,
             justifyContent: 'center',
             alignItems: 'center',
           }}
-          style={{
-            height: 40,
-            backgroundColor: LIGHTGRAY,
-            justifyContent: 'center',
-            alignItems: 'center',
-          }}
-        />
+          onPress={
+            image === undefined ? handleAddButtonPress : handleImagePress
+          }>
+          {image === undefined ? (
+            <View
+              style={{
+                flexDirection: 'row',
+                height: 40,
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}>
+              <PhotoIcon />
+              <Body14M style={{ marginLeft: 10 }}>이미지 등록</Body14M>
+            </View>
+          ) : (
+            <Image src={image.uri} style={{ width: '100%', aspectRatio: 1 }} />
+          )}
+        </TouchableOpacity>
         <View
           style={{
             marginHorizontal: width * 0.04,

--- a/src/hooks/useImagePicker.ts
+++ b/src/hooks/useImagePicker.ts
@@ -26,8 +26,7 @@ export interface PhotoType {
   uri: string;
 }
 
-export default function useImagePicker(
-  photo: undefined | PhotoType,
+export function useImagePicker(
   setPhoto: Dispatch<SetStateAction<PhotoType | undefined>>,
 ) {
   const CameraActions: Action[] = [
@@ -139,6 +138,165 @@ export default function useImagePicker(
       { text: '취소', style: 'destructive' },
     ]);
   };
+  return [handleAddButtonPress, handleImagePress];
+}
+
+export function useImagePickers(
+  setPhotos: Dispatch<SetStateAction<PhotoType[]>>,
+  max: number,
+) {
+  const CameraActions: Action[] = [
+    //카메라 & 갤러리 세팅
+    {
+      title: '카메라',
+      type: 'capture',
+      options: {
+        mediaType: 'photo',
+        includeBase64: false,
+        maxHeight: 300,
+        maxWidth: 300,
+      },
+    },
+    {
+      title: '앨범',
+      type: 'library',
+      options: {
+        mediaType: 'photo',
+        includeBase64: false,
+        maxHeight: 300,
+        maxWidth: 300,
+      },
+    },
+  ];
+
+  const onButtonPress = useCallback(
+    (
+      type: string,
+      options: ImagePicker.CameraOptions | ImagePicker.ImageLibraryOptions,
+      callback: (selectedPhotos: PhotoType[]) => void,
+    ) => {
+      if (type === 'capture') {
+        ImagePicker.launchCamera(options, response => {
+          if (response.errorCode !== undefined) {
+            console.log('ImagePicker Error: ', response.errorMessage);
+          } else if (!response.didCancel) {
+            const selectedPhotos = response.assets!.map(asset => {
+              if (asset.uri === undefined)
+                throw console.error('ImagePicker error: uri not found');
+              else
+                return {
+                  fileName: asset.fileName,
+                  width: asset.width,
+                  height: asset.height,
+                  uri: asset.uri,
+                };
+            });
+            callback(selectedPhotos);
+          }
+        });
+      } else {
+        ImagePicker.launchImageLibrary(options, response => {
+          if (response.errorCode !== undefined) {
+            console.log('ImagePicker Error: ', response.errorMessage);
+          } else if (!response.didCancel) {
+            const selectedPhotos = response.assets!.map(asset => {
+              if (asset.uri === undefined)
+                throw console.error('ImagePicker error: uri not found');
+              else
+                return {
+                  fileName: asset.fileName,
+                  width: asset.width,
+                  height: asset.height,
+                  uri: asset.uri,
+                };
+            });
+            callback(selectedPhotos);
+          }
+        });
+      }
+    },
+    [],
+  );
+
+  const handleAddButtonPress = (images: PhotoType[]) => {
+    const newImages = images;
+
+    Alert.alert('사진 선택', '', [
+      {
+        text: '카메라',
+        onPress: () =>
+          onButtonPress(
+            CameraActions[0].type,
+            {
+              selectionLimit: max - images.length,
+              ...CameraActions[0].options,
+            },
+            selectedPhotos => {
+              setPhotos(newImages.concat(selectedPhotos));
+            },
+          ),
+      },
+      {
+        text: '앨범',
+        onPress: () =>
+          onButtonPress(
+            CameraActions[1].type,
+            {
+              selectionLimit: max - images.length,
+              ...CameraActions[1].options,
+            },
+            selectedPhotos => {
+              setPhotos(newImages.concat(selectedPhotos));
+            },
+          ),
+      },
+      { text: '취소', style: 'destructive' },
+    ]);
+  };
+
+  const handleImagePress = (imageIndex: number, images: PhotoType[]) => {
+    const newImages = images;
+
+    Alert.alert('사진을 수정하시겠습니까?', '', [
+      {
+        text: '카메라',
+        onPress: () =>
+          onButtonPress(
+            CameraActions[0].type,
+            {
+              selectionLimit: 1,
+              ...CameraActions[0].options,
+            },
+            selectedPhotos => {
+              newImages[imageIndex] = selectedPhotos[0];
+              setPhotos(newImages);
+            },
+          ),
+      },
+      {
+        text: '앨범',
+        onPress: () =>
+          onButtonPress(
+            CameraActions[1].type,
+            {
+              selectionLimit: 1,
+              ...CameraActions[1].options,
+            },
+            selectedPhotos => {
+              newImages[imageIndex] = selectedPhotos[0];
+              setPhotos(newImages);
+            },
+          ),
+      },
+      {
+        text: '삭제',
+        // 삭제
+        onPress: () => setPhotos(newImages.splice(imageIndex, 1)),
+      },
+      { text: '취소', style: 'destructive' },
+    ]);
+  };
+
   return [handleAddButtonPress, handleImagePress];
 }
 

--- a/src/hooks/useImagePicker.ts
+++ b/src/hooks/useImagePicker.ts
@@ -1,0 +1,315 @@
+import { Dispatch, SetStateAction, useCallback } from 'react';
+import { Alert } from 'react-native';
+import * as ImagePicker from 'react-native-image-picker';
+
+interface Action {
+  title: string;
+  type: 'capture' | 'library';
+  options: ImagePicker.CameraOptions | ImagePicker.ImageLibraryOptions;
+}
+
+interface ImagePickerProps {
+  photo: undefined | PhotoType;
+  setPhoto: Dispatch<SetStateAction<PhotoType>>;
+}
+
+interface ImagesPickerProps {
+  photo: PhotoType[];
+  setPhoto: Dispatch<SetStateAction<PhotoType[]>>;
+  max: number;
+}
+
+export interface PhotoType {
+  fileName: string | undefined;
+  width: number | undefined;
+  height: number | undefined;
+  uri: string;
+}
+
+export default function useImagePicker(
+  photo: undefined | PhotoType,
+  setPhoto: Dispatch<SetStateAction<PhotoType | undefined>>,
+) {
+  const CameraActions: Action[] = [
+    //카메라 & 갤러리 세팅
+    {
+      title: '카메라',
+      type: 'capture',
+      options: {
+        selectionLimit: 1,
+        mediaType: 'photo',
+        includeBase64: false,
+        maxHeight: 300,
+        maxWidth: 300,
+      },
+    },
+    {
+      title: '앨범',
+      type: 'library',
+      options: {
+        selectionLimit: 1,
+        mediaType: 'photo',
+        includeBase64: false,
+        maxHeight: 300,
+        maxWidth: 300,
+      },
+    },
+  ];
+
+  const onButtonPress = useCallback(
+    (
+      type: string,
+      options: ImagePicker.CameraOptions | ImagePicker.ImageLibraryOptions,
+    ) => {
+      if (type === 'capture') {
+        ImagePicker.launchCamera(options, response => {
+          if (response.errorCode !== undefined) {
+            console.log('ImagePicker Error: ', response.errorMessage);
+          } else if (!response.didCancel) {
+            const selectedPhotos = response.assets!.map(asset => {
+              if (asset.uri === undefined)
+                throw console.error('ImagePicker error: uri not found');
+              else
+                return {
+                  fileName: asset.fileName,
+                  width: asset.width,
+                  height: asset.height,
+                  uri: asset.uri,
+                };
+            });
+            setPhoto(selectedPhotos[0]);
+          }
+        });
+      } else {
+        ImagePicker.launchImageLibrary(options, response => {
+          if (response.errorCode !== undefined) {
+            console.log('ImagePicker Error: ', response.errorMessage);
+          } else if (!response.didCancel) {
+            const selectedPhotos = response.assets!.map(asset => {
+              if (asset.uri === undefined)
+                throw console.error('ImagePicker error: uri not found');
+              else
+                return {
+                  fileName: asset.fileName,
+                  width: asset.width,
+                  height: asset.height,
+                  uri: asset.uri,
+                };
+            });
+            setPhoto(selectedPhotos[0]);
+          }
+        });
+      }
+    },
+    [],
+  );
+
+  const handleAddButtonPress = () => {
+    Alert.alert('사진 선택', '', [
+      {
+        text: '카메라',
+        onPress: () =>
+          onButtonPress(CameraActions[0].type, CameraActions[0].options),
+      },
+      {
+        text: '앨범',
+        onPress: () =>
+          onButtonPress(CameraActions[1].type, CameraActions[1].options),
+      },
+      { text: '취소', style: 'destructive' },
+    ]);
+  };
+
+  const handleImagePress = () => {
+    Alert.alert('사진을 수정하시겠습니까?', '', [
+      {
+        text: '카메라',
+        onPress: () =>
+          onButtonPress(CameraActions[0].type, CameraActions[0].options),
+      },
+      {
+        text: '앨범',
+        onPress: () =>
+          onButtonPress(CameraActions[1].type, CameraActions[1].options),
+      },
+      {
+        text: '삭제',
+        onPress: () => setPhoto(undefined),
+      },
+      { text: '취소', style: 'destructive' },
+    ]);
+  };
+  return [handleAddButtonPress, handleImagePress];
+}
+
+// const PhotoOptions = ({
+//   buttonLabel,
+//   photo,
+//   setPhoto,
+//   max,
+//   style,
+//   imageStyle,
+//   containerStyle,
+// }: PhotoProps) => {
+//   const CameraActions: Action[] = [
+//     //카메라 & 갤러리 세팅
+//     {
+//       title: '카메라',
+//       type: 'capture',
+//       options: {
+//         selectionLimit: max - (photo === undefined ? 0 : photo.length),
+//         mediaType: 'photo',
+//         includeBase64: false,
+//         maxHeight: 300,
+//         maxWidth: 300,
+//       },
+//     },
+//     {
+//       title: '앨범',
+//       type: 'library',
+//       options: {
+//         selectionLimit: max - (photo === undefined ? 0 : photo.length),
+//         mediaType: 'photo',
+//         includeBase64: false,
+//         maxHeight: 300,
+//         maxWidth: 300,
+//       },
+//     },
+//   ];
+
+//   const onButtonPress = useCallback(
+//     (
+//       type: string,
+//       options: ImagePicker.CameraOptions | ImagePicker.ImageLibraryOptions,
+//     ) => {
+//       if (type === 'capture') {
+//         ImagePicker.launchCamera(options, response => {
+//           if (response.errorCode !== undefined) {
+//             console.log('ImagePicker Error: ', response.errorMessage);
+//           } else if (!response.didCancel) {
+//             const selectedPhotos = response.assets!.map(asset => {
+//               if (asset.uri === undefined)
+//                 throw console.error('ImagePicker error: uri not found');
+//               else
+//                 return {
+//                   fileName: asset.fileName,
+//                   width: asset.width,
+//                   height: asset.height,
+//                   uri: asset.uri,
+//                 };
+//             });
+//             if (photo === undefined) setPhoto(selectedPhotos);
+//             else setPhoto(photo.concat(selectedPhotos));
+//           }
+//         });
+//       } else {
+//         ImagePicker.launchImageLibrary(options, response => {
+//           if (response.errorCode !== undefined) {
+//             console.log('ImagePicker Error: ', response.errorMessage);
+//           } else if (!response.didCancel) {
+//             const selectedPhotos = response.assets!.map(asset => {
+//               if (asset.uri === undefined)
+//                 throw console.error('ImagePicker error: uri not found');
+//               else
+//                 return {
+//                   fileName: asset.fileName,
+//                   width: asset.width,
+//                   height: asset.height,
+//                   uri: asset.uri,
+//                 };
+//             });
+//             if (photo === undefined) setPhoto(selectedPhotos);
+//             else setPhoto(photo.concat(selectedPhotos));
+//           }
+//         });
+//       }
+//     },
+//     [],
+//   );
+
+//   return (
+//     <View style={{ backgroundColor: LIGHTGRAY2, ...containerStyle }}>
+//       <PhotosInput>
+//         <View style={{ flex: 1 }}>
+//           <Carousel
+//             data={
+//               photo === undefined
+//                 ? [undefined]
+//                 : photo.length < max
+//                   ? [photo, undefined]
+//                   : photo
+//             }
+//             renderItem={({
+//               item,
+//               idx,
+//             }: {
+//               item: undefined | PhotoType;
+//               idx: number;
+//             }) => {
+//               return (
+//                 <View key={idx}>
+//                   {item === undefined ? (
+//                     <TouchableOpacity
+//                       style={{
+//                         flexDirection: 'row',
+//                         alignItems: 'center',
+//                         paddingHorizontal: 16,
+//                         backgroundColor: 'LIGHTGRAY',
+//                         borderRadius: 6,
+//                         marginBottom: 20,
+//                         paddingVertical: 6,
+//                         ...style,
+//                       }}
+//                       onPress={() => {
+//                         Alert.alert('사진 선택', '', [
+//                           {
+//                             text: '카메라',
+//                             onPress: () =>
+//                               onButtonPress(
+//                                 CameraActions[0].type,
+//                                 CameraActions[0].options,
+//                               ),
+//                           },
+//                           {
+//                             text: '앨범',
+//                             onPress: () =>
+//                               onButtonPress(
+//                                 CameraActions[1].type,
+//                                 CameraActions[1].options,
+//                               ),
+//                           },
+//                           { text: '취소', style: 'destructive' },
+//                         ]);
+//                       }}>
+//                       {buttonLabel && (
+//                         <>
+//                           <PhotoIcon />
+//                           <Body14M style={{ marginLeft: 10 }}>
+//                             {buttonLabel}
+//                           </Body14M>
+//                         </>
+//                       )}
+//                     </TouchableOpacity>
+//                   ) : (
+//                     <></>
+//                   )}
+//                 </View>
+//                 // item.map((subItem: any) => (
+//                 //   <View style={{ height: 350, paddingLeft: 20, paddingRight: 20, paddingTop: 20 }}>
+//                 //     <ImageBackground
+//                 //       key={subItem.id}
+//                 //       source={{ uri: subItem.uri }}
+//                 //       style={{ width: "auto", height: "100%" }}
+//                 //       alt={subItem.fileName}
+//                 //     />
+//                 //   </View>
+//                 // ))
+//               );
+//             }}
+//             slider={photo !== undefined && photo.length > 0}
+//           />
+//         </View>
+//       </PhotosInput>
+//     </View>
+//   );
+// };


### PR DESCRIPTION
### 작업 내용
* `useImagePicker` 커스텀 훅 구현
> 단일 이미지 상태 관리의 경우 `useImagePicker`, 이미지 배열 상태 관리의 경우 `useImagePickers` 호출. 이미지 추가 버튼 / 현재 첨부된 이미지의 press event handler로 `handleAddButtonPress`, `handleImagePress` 반환.

* 포트폴리오 작성 페이지, 리포머 프로필 등록 페이지에서 기존 로직 대체
* `PhotoOptions` 수정사항 롤백

### 작업 예정
* 이미지 배열과 연결되는 `ImageCarousel` 컴포넌트 작업 중
> 피그마 상으로 상세화면 컴포넌트 - 이미지 등록 박스에 해당